### PR TITLE
Update initializer code with Rails.root and Rails.env

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,11 +549,8 @@ production: redis1.example.com:6379
 And our initializer:
 
 ```ruby
-rails_root = ENV['RAILS_ROOT'] || File.dirname(__FILE__) + '/../..'
-rails_env = ENV['RAILS_ENV'] || 'development'
-
-split_config = YAML.load_file(rails_root + '/config/split.yml')
-Split.redis = split_config[rails_env]
+split_config = YAML.load_file(Rails.root.join('config', 'split.yml'))
+Split.redis = split_config[Rails.env]
 ```
 
 ## Namespaces


### PR DESCRIPTION
Hi,

the snippet not works anymore with Rails 4.1. I've updated with the new syntax, works even with Rails 2.10. See [env](http://apidock.com/rails/Rails/env/class) and [root](http://apidock.com/rails/Rails/root/class) doc for more info.