### PR TITLE
Added metadata to experiment.

### DIFF
--- a/lib/split/configuration.rb
+++ b/lib/split/configuration.rb
@@ -141,6 +141,10 @@ module Split
             experiment_config[experiment_name.to_sym][:goals] = goals
           end
 
+          if metadata = value_for(settings, :metadata)
+            experiment_config[experiment_name.to_sym][:metadata] = metadata
+          end
+
           if (resettable = value_for(settings, :resettable)) != nil
             experiment_config[experiment_name.to_sym][:resettable] = resettable
           end

--- a/lib/split/trial.rb
+++ b/lib/split/trial.rb
@@ -1,15 +1,21 @@
 module Split
   class Trial
     attr_accessor :experiment
+    attr_accessor :metadata
 
     def initialize(attrs = {})
       self.experiment   = attrs.delete(:experiment)
       self.alternative  = attrs.delete(:alternative)
+      self.metadata  = attrs.delete(:metadata)
 
       @user             = attrs.delete(:user)
       @options          = attrs
 
       @alternative_choosen = false
+    end
+
+    def metadata
+      @metadata ||= experiment.metadata[alternative.name]
     end
 
     def alternative

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -90,6 +90,36 @@ describe Split::Configuration do
         end
       end
 
+      context "in a configuration with metadata" do
+        before do
+          experiments_yaml = <<-eos
+            my_experiment:
+              alternatives:
+                - name: Control Opt
+                  percent: 67
+                - name: Alt One
+                  percent: 10
+                - name: Alt Two
+                  percent: 23
+              metadata:
+                Control Opt:
+                  text: 'Control Option'
+                Alt One:
+                  text: 'Alternative One'
+                Alt Two:
+                  text: 'Alternative Two'
+              resettable: false
+            eos
+          @config.experiments = YAML.load(experiments_yaml)
+        end
+
+        it 'should have metadata on the experiment' do
+          meta = @config.normalized_experiments[:my_experiment][:metadata]
+          expect(meta).to_not be nil
+          expect(meta['Control Opt']['text']).to eq('Control Option')
+        end
+      end
+
       context "in a complex configuration" do
         before do
           experiments_yaml = <<-eos
@@ -120,6 +150,7 @@ describe Split::Configuration do
           expect(@config.metrics).not_to be_nil
           expect(@config.metrics.keys).to eq([:my_metric])
         end
+
       end
     end
 

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -147,6 +147,29 @@ describe Split::Experiment do
 
     end
 
+    describe '#metadata' do
+      let(:experiment) { Split::Experiment.new('basket_text', :alternatives => ['Basket', "Cart"], :algorithm => Split::Algorithms::Whiplash, :metadata => meta) }
+      context 'simple hash' do
+        let(:meta) {  { 'basket' => 'a', 'cart' => 'b' } }
+        it "should persist metadata in redis" do
+          experiment.save
+          e = Split::ExperimentCatalog.find('basket_text')
+          expect(e).to eq(experiment)
+          expect(e.metadata).to eq(meta)
+        end
+      end
+
+      context 'nested hash' do
+        let(:meta) {  { 'basket' => { 'one' => 'two' }, 'cart' => 'b' } }
+        it "should persist metadata in redis" do
+          experiment.save
+          e = Split::ExperimentCatalog.find('basket_text')
+          expect(e).to eq(experiment)
+          expect(e.metadata).to eq(meta)
+        end
+      end
+    end
+
     it "should persist algorithm in redis" do
       experiment = Split::Experiment.new('basket_text', :alternatives => ['Basket', "Cart"], :algorithm => Split::Algorithms::Whiplash)
       experiment.save

--- a/spec/trial_spec.rb
+++ b/spec/trial_spec.rb
@@ -33,6 +33,27 @@ describe Split::Trial do
     end
   end
 
+  describe "metadata" do
+    let(:alternatives) { ['basket', 'cart'] }
+    let(:metadata) { Hash[alternatives.map { |k| [k, "Metadata for #{k}"] }] }
+    let(:experiment) do
+      Split::Experiment.new('basket_text', :alternatives => alternatives, :metadata => metadata).save
+    end
+
+    it 'has metadata on each trial' do
+      trial = Split::Trial.new(:experiment => experiment, :user => user, :metadata => metadata['cart'],
+                               :override => 'cart')
+      expect(trial.metadata).to eq(metadata['cart'])
+    end
+
+    it 'has metadata on each trial from the experiment' do
+      trial = Split::Trial.new(:experiment => experiment, :user => user)
+      trial.choose!
+      expect(trial.metadata).to eq(metadata[trial.alternative.name])
+      expect(trial.metadata).to match /#{trial.alternative.name}/
+    end
+  end
+
   describe "#choose!" do
     def expect_alternative(trial, alternative_name)
       3.times do


### PR DESCRIPTION

This allows metadata to be associated with an experiment. Very useful when you need more than an alternative name to change behaviour. The current way to solve this problem is to have a conditional statement around the experiment code to decide on the conditional branch. With this change, it is possible to choose what is in the trial metadata.


## Before

```ruby
 if (trial.alternative.name == "a")
  # get the greeting for A
 else (trial.alternative.name == "b")
  # get the greeting for B
 end
```

## After


```yaml
my_first_experiment:
  alternatives:
    - a
    - b
  meta:
     a:
       text: "Have a fantastic day"
     b:
       text: "Don't get hit by a bus"
```

``` ruby
> trial.alternative.name
# "a"
> trial.metadata['text']
# "Have a fantastic day"
```


Fixes #288