### PR TITLE
Remove body "max-width" from dashboard.

### DIFF
--- a/lib/split/dashboard/public/style.css
+++ b/lib/split/dashboard/public/style.css
@@ -7,7 +7,6 @@ html {
 body {
   padding: 0 10px;
   margin: 10px auto 0;
-  max-width:800px;
 }
 
 .header {


### PR DESCRIPTION
In the dashboad, to prevent experiments with long names from overflowing:
![with max-width](https://cloud.githubusercontent.com/assets/2476493/6419279/b17560fe-be70-11e4-977c-553102efc820.png)

Remove the `max-width: 800px` style from the body:
![without max-width](https://cloud.githubusercontent.com/assets/2476493/6419294/caffc76c-be70-11e4-856f-c777f68fa9e5.png)

