### PR TITLE
[private-methods-in-controllers] prevents split helper-methods to become...

### DIFF
--- a/lib/split/encapsulated_helper.rb
+++ b/lib/split/encapsulated_helper.rb
@@ -14,9 +14,12 @@ module Split
 
     class ContextShim
       include Split::Helper
+      public :ab_test, :finished
+
       def initialize(context)
         @context = context
       end
+
       def ab_user
         @ab_user ||= Split::Persistence.adapter.new(@context)
       end

--- a/lib/split/helper.rb
+++ b/lib/split/helper.rb
@@ -1,5 +1,6 @@
 module Split
   module Helper
+    module_function
 
     def ab_test(metric_descriptor, control = nil, *alternatives)
       begin
@@ -129,8 +130,6 @@ module Split
       end
       return experiment_pairs
     end
-
-    protected
 
     def normalize_metric(metric_descriptor)
       if Hash === metric_descriptor


### PR DESCRIPTION
... actions in the Rails controllers

When we use Split gem with Rails we mixin Split::Helper and its methods could potentially became actions in the controllers, since it's public scope right now.
Lets make Helper methods private to prevent possible security problem, and it will also add the possibility for usage like this ```Split::Helper.ab_test()```