### PR TITLE
Update documentation regarding Split::Experiment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Bugfixes:
 
 ## 1.1.0 (January 9th, 2015)
 
+Changes:
+
+  - Public class methods on `Split::Experiment` (e.g., `find_or_create`)
+    have been moved to `Split::ExperimentCatalog`.
+
 Features:
 
   - Decouple trial from Split::Helper (@joshdover, #286)

--- a/README.md
+++ b/README.md
@@ -614,7 +614,7 @@ conduct experiments that are not tied to a web session.
 
 ```ruby
 # create a new experiment
-experiment = Split::Experiment.find_or_create('color', 'red', 'blue')
+experiment = Split::ExperimentCatalog.find_or_create('color', 'red', 'blue')
 # create a new trial
 trial = Split::Trial.new(:experiment => experiment)
 # run trial


### PR DESCRIPTION
Am I correct in believing that this is a breaking change? If so, was it intentional?